### PR TITLE
Handle different response format

### DIFF
--- a/lib/clienthttp.js
+++ b/lib/clienthttp.js
@@ -51,17 +51,16 @@ function httpGet(rawUrl, callback){
 }
 
 function handleResponse(res, callback, data, headers){
-    res.setEncoding("utf8");
     setCookieByHttpRes(res);
-    var buffer = "";
+    var buffer = [];
     res.on("data", function(chunk){
         if (chunk && chunk.length>0){
-            buffer += chunk;
+            buffer.push(chunk);
         }
     });
     res.on("end", function(){
         if (res.statusCode==200){
-            callback && callback(buffer, null, _cookie, res.headers);
+            callback && callback(Buffer.concat(buffer), null, _cookie, res.headers);
         }else if (res.statusCode==301 || res.statusCode==302){
             var nextTarget = res.headers.location;
             process.nextTick(function(){
@@ -69,7 +68,7 @@ function handleResponse(res, callback, data, headers){
             });
         }else{
             callback && callback(null, 
-                "Server return " + res.statusCode + ": " + buffer);
+                "Server return " + res.statusCode + ": " + Buffer.concat(buffer).toString());
         }
     });
 }

--- a/lib/clienthttp.js
+++ b/lib/clienthttp.js
@@ -26,11 +26,11 @@ function httpRequest(rawUrl, callback, data, headers){ // data and custom header
     var req;
     if (options._protocol=="https" && !options.agent){
         req = https.request(options, function(res){
-            handleResponese(res, callback, data, headers);
+            handleResponse(res, callback, data, headers);
         });
     }else{
         req = http.request(options, function(res){
-            handleResponese(res, callback, data, headers);
+            handleResponse(res, callback, data, headers);
         });
     }
     req.on('socket', function(socket){
@@ -50,7 +50,7 @@ function httpGet(rawUrl, callback){
     httpRequest(rawUrl, callback);
 }
 
-function handleResponese(res, callback, data, headers){
+function handleResponse(res, callback, data, headers){
     res.setEncoding("utf8");
     setCookieByHttpRes(res);
     var buffer = "";

--- a/test/http-base.js
+++ b/test/http-base.js
@@ -1,6 +1,6 @@
 var http = require('../index.js');
 
 http.get("http://www.google.com/", function(data, err){
-    data && console.log(data);
+    data && console.log(data.toString());
     err && console.log(err);
 });

--- a/test/http-custom-header.js
+++ b/test/http-custom-header.js
@@ -2,6 +2,6 @@ var http = require('../index.js');
 
 // we use iPhone as our user-agent and see what happen
 http.request("http://twitter.com/", function(data, err){
-    data && console.log(data);
+    data && console.log(data.toString());
     err && console.log(err);
 }, null, {"User-Agent": "iPhone"});

--- a/test/http-manualProxy.js
+++ b/test/http-manualProxy.js
@@ -2,6 +2,6 @@ var http = require('../index.js');
 
 http.setProxy('http://127.0.0.1:8081');
 http.get("http://www.google.com/", function(data, err){
-    data && console.log(data);
+    data && console.log(data.toString());
     err && console.log(err);
 });

--- a/test/http-post.js
+++ b/test/http-post.js
@@ -1,6 +1,6 @@
 var http = require('../index.js');
 
 http.request("http://httpbin.org/post", function(data, err){
-    data && console.log(data);
+    data && console.log(data.toString());
     err && console.log(err);
 }, "fname=hello&lname=world", {"Content-Type":"application/x-www-form-urlencoded"});

--- a/test/https-base.js
+++ b/test/https-base.js
@@ -1,6 +1,6 @@
 var http = require('../index.js');
 
 http.get("https://www.google.com/", function(data, err){
-    data && console.log(data);
+    data && console.log(data.toString());
     err && console.log(err);
 });


### PR DESCRIPTION
The objective of this pull request is to make node-http-client able to handle different type of response format.

Currently, node-http-client can only support text response. But if you do a GET on another type (application/pdf for instance), response data will be cast to String, and obvioulsy data will not be exploitable.

This pull request make `handleResponse` method deal only with chunk as Buffer, and no longer as String, thus any type can be supported.
